### PR TITLE
Update READMD.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 ### jekyll 설치 및 개발 환경 세팅
 
 ```bash
-$ gem install jekyll
 $ cd buzzni.github.com
 $ bundle install
 ```
@@ -18,7 +17,7 @@ $ bundle install
 ### 개발 서버 띄우기
 
 ```bash
-$ jekyll serve
+$ bundle exec jekyll serve
 ```
 입력 후 브라우저에서 **127.0.0.1:4000** 으로 들어가면 확인 할수 있습니다.
 


### PR DESCRIPTION
jekyll 설치와 실행을 bundle을 통해서 하는것으로 문서 수정했습니다.

기존 방법대로 설치시 gem으로 설치된 jekyll과 bundle로 설치된 jekyll의 버전이 달라
실행이 안되거나, 실행환경이 달라질 수 있어서 수정했습니다.